### PR TITLE
Replace number pwm on environment variable

### DIFF
--- a/files/root/fail.sh
+++ b/files/root/fail.sh
@@ -9,17 +9,17 @@ led_off green
 echo 250 > /sys/class/leds/red/delay_on
 echo 250 > /sys/class/leds/red/delay_off
 
-echo 250000 > /sys/class/pwm/pwmchip0/pwm0/period
-echo 125000 > /sys/class/pwm/pwmchip0/pwm0/duty_cycle
+echo 250000 > /sys/class/pwm/pwmchip0/pwm$WB_PWM_BUZZER/period
+echo 125000 > /sys/class/pwm/pwmchip0/pwm$WB_PWM_BUZZER/duty_cycle
 
 while true
 do
 	for ((a=0; a<4; a++))
 	do
 		sleep 0.1
-		echo 1 > /sys/class/pwm/pwmchip0/pwm0/enable
+		echo 1 > /sys/class/pwm/pwmchip0/pwm$WB_PWM_BUZZER/enable
 		sleep 0.1
-		echo 0 > /sys/class/pwm/pwmchip0/pwm0/enable
+		echo 0 > /sys/class/pwm/pwmchip0/pwm$WB_PWM_BUZZER/enable
 	done
 	sleep 10
 done

--- a/files/root/not_fail.sh
+++ b/files/root/not_fail.sh
@@ -2,7 +2,7 @@
 
 . /etc/wb_env.sh
 
-echo 0 > /sys/class/pwm/pwmchip0/pwm0/enable
+echo 0 > /sys/class/pwm/pwmchip0/pwm$WB_PWM_BUZZER/enable
 
 wb_source hardware
 led_blink green


### PR DESCRIPTION
На WB7 не срабатывал buzzer из-за разных pwm. Заменил в скриптах управления бузером на переменную окружения.