### PR TITLE
fix configs displacement broken in 1.7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PREFIX = /usr
 
 install:
+	mkdir -p $(DESTDIR)/mnt/data/etc
 	cp -r files/etc $(DESTDIR)/mnt/data/etc
 	install -Dm0755 files/usr/lib/wb-demo-kit-configs/*.sh -t $(DESTDIR)$(PREFIX)/lib/wb-demo-kit-configs
 	install -Dm0644 files/usr/share/wb-demo-kit-configs/*.j2 -t $(DESTDIR)$(PREFIX)/share/wb-demo-kit-configs

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX = /usr
 
 install:
-	cp -r files/etc $(DESTDIR)/etc
+	cp -r files/etc $(DESTDIR)/mnt/data/etc
 	install -Dm0755 files/usr/lib/wb-demo-kit-configs/*.sh -t $(DESTDIR)$(PREFIX)/lib/wb-demo-kit-configs
 	install -Dm0644 files/usr/share/wb-demo-kit-configs/*.j2 -t $(DESTDIR)$(PREFIX)/share/wb-demo-kit-configs
 	minify files/usr/share/wb-demo-kit-configs/WB6.svg -o $(DESTDIR)$(PREFIX)/share/wb-demo-kit-configs/WB6.svg

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-demo-kit-configs (1.7.4) stable; urgency=medium
+
+  * Fix configs displacement broken in 1.7.2
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Tue, 09 Jul 2024 15:00:41 +0500
+
 wb-demo-kit-configs (1.7.3) stable; urgency=medium
 
   * Add missed wb-utils dependency, no functional changes

--- a/debian/wb-demo-kit-configs.displace
+++ b/debian/wb-demo-kit-configs.displace
@@ -1,3 +1,4 @@
-/etc/wb-hardware.conf.wb-demo-kit
-/etc/wb-mqtt-serial.conf.wb-demo-kit
-/etc/wb-webui.conf.wb-demo-kit
+# displacement in /mnt/data is intentional as we don't want to interfere with wb-configs
+/mnt/data/etc/wb-hardware.conf.wb-demo-kit
+/mnt/data/etc/wb-mqtt-serial.conf.wb-demo-kit
+/mnt/data/etc/wb-webui.conf.wb-demo-kit

--- a/debian/wb-demo-kit-configs.postinst
+++ b/debian/wb-demo-kit-configs.postinst
@@ -46,9 +46,10 @@ cat <<EOF > "/tmp/vars.json"
 }
 EOF
 
-j2 ${CONF_DIR}/${HARDWARE_CONF_FNAME} "/tmp/vars.json" > /etc/wb-hardware.conf.wb-demo-kit
-j2 ${CONF_DIR}/${SERIAL_CONF_FNAME} "/tmp/vars.json" > /etc/wb-mqtt-serial.conf.wb-demo-kit
-j2 ${CONF_DIR}/${WEBUI_CONF_FNAME} "/tmp/vars.json" > /etc/wb-webui.conf.wb-demo-kit
+# /mnt/data is intentional here, as we don't want to interfere with wb-configs scripts
+j2 ${CONF_DIR}/${HARDWARE_CONF_FNAME} "/tmp/vars.json" > /mnt/data/etc/wb-hardware.conf.wb-demo-kit
+j2 ${CONF_DIR}/${SERIAL_CONF_FNAME} "/tmp/vars.json" > /mnt/data/etc/wb-mqtt-serial.conf.wb-demo-kit
+j2 ${CONF_DIR}/${WEBUI_CONF_FNAME} "/tmp/vars.json" > /mnt/data/etc/wb-webui.conf.wb-demo-kit
 
 # restart services
 deb-systemd-invoke restart wb-mqtt-serial


### PR DESCRIPTION
Кажется, в 1.7.2 сломали displacement конфигов, сделав его в /etc. вернул в /mnt/data