### PR TITLE
fix incorrect json in energomera ce_102 case

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-demo-kit-configs (1.8.1) stable; urgency=medium
+
+  * Fix incorrect json in energomera ce_102 case
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Mon, 26 Aug 2024 17:32:11 +0300
+
 wb-demo-kit-configs (1.8.0) stable; urgency=medium
 
   * Add Energomera CE102

--- a/files/usr/share/wb-demo-kit-configs/wb-mqtt-serial.conf.wb-demo-kit.j2
+++ b/files/usr/share/wb-demo-kit-configs/wb-mqtt-serial.conf.wb-demo-kit.j2
@@ -608,7 +608,7 @@
           "id": "energy_meter",
           "device_type" : "energomera_ce102",
           "slave_id" : "1"
-        },
+        }
         {% endif -%}
       ],
       "enabled" : true,


### PR DESCRIPTION
Начали делать чемоданы с новым счётчиком, а там упдатер не может обновить устройства.
Посмотрел, в чем дело - оказывается, джей сон - не джей сон
![image](https://github.com/user-attachments/assets/d92a13fe-f981-4e8f-90f0-38650e734950)
